### PR TITLE
Changes for RTL Generation

### DIFF
--- a/peak/__init__.py
+++ b/peak/__init__.py
@@ -1,6 +1,6 @@
 
 from .adt import ISABuilder, Product, Sum, Enum, Tuple
-from .register import Register
+from .register import gen_register
 from .memory import Memory, RAM, ROM
 
 from .peak import Peak, name_outputs

--- a/peak/adt.py
+++ b/peak/adt.py
@@ -256,6 +256,13 @@ class Enum(ISABuilder, pyEnum):
     def __repr__(self):
         return f'<{self.__class__.__name__}.{self.name}>'
 
+    @classmethod
+    def bit_length(cls):
+        n = 1
+        for value in cls:
+            n = max(n, value.value.bit_length())
+        return n
+
 def is_enum(enum) -> bool:
     return isinstance(enum, Enum)
 

--- a/peak/memory.py
+++ b/peak/memory.py
@@ -1,12 +1,12 @@
 from .peak import Peak
-from .register import Register
+from .register import gen_register
 
 class ROM(Peak):
     def __init__(self, type, n, mem, init=0):
         self.mem = []
         for i in range(n):
             data = mem[i] if i < len(mem) else init
-            self.mem.append( Register(type, data) )
+            self.mem.append( gen_register(type)(data) )
         
     def __call__(self, addr):
         return self.mem[int(addr)]()

--- a/peak/memory.py
+++ b/peak/memory.py
@@ -6,7 +6,7 @@ class ROM(Peak):
         self.mem = []
         for i in range(n):
             data = mem[i] if i < len(mem) else init
-            self.mem.append( gen_register(type)(data) )
+            self.mem.append( gen_register(type, init=data)() )
         
     def __call__(self, addr):
         return self.mem[int(addr)]()

--- a/peak/memory.py
+++ b/peak/memory.py
@@ -1,12 +1,13 @@
 from .peak import Peak
 from .register import gen_register
+from hwtypes import BitVector
 
 class ROM(Peak):
     def __init__(self, type, n, mem, init=0):
         self.mem = []
         for i in range(n):
             data = mem[i] if i < len(mem) else init
-            self.mem.append( gen_register(type, init=data)() )
+            self.mem.append( gen_register(BitVector.get_family(), type, init=data)() )
         
     def __call__(self, addr):
         return self.mem[int(addr)]()

--- a/peak/pe/mode.py
+++ b/peak/pe/mode.py
@@ -12,14 +12,14 @@ class Mode(Enum):
     DELAY = 3   # Register written with input value, previous value returned
 
 
-def gen_register_mode(family: TypeFamily, datawidth=None):
+def gen_register_mode(family: TypeFamily, datawidth=None, init=0):
     T = family
     if datawidth is not None:
         T = T[datawidth]
 
     class RegisterMode(Peak):
-        def __init__(self, init=0):
-            self.register: T = gen_register(T)(init)
+        def __init__(self):
+            self.register: T = gen_register(T, init)()
 
         def reset(self):
             self.register.reset()

--- a/peak/pe/mode.py
+++ b/peak/pe/mode.py
@@ -1,27 +1,41 @@
-from peak import Peak, Register, Enum
+from peak import Peak, gen_register
+from peak.adt import Enum
 from .lut import Bit
+from hwtypes import TypeFamily
 
+
+# Field for specifying register modes
 class Mode(Enum):
-    CONST = 0
-    VALID = 1
-    BYPASS = 2
-    DELAY = 3
+    CONST = 0   # Register returns constant in constant field
+    VALID = 1   # Register written with clock enable, previous value returned
+    BYPASS = 2  # Register is bypassed and input value is returned
+    DELAY = 3   # Register written with input value, previous value returned
 
-class RegisterMode(Peak):
-    def __init__(self, init = 0):
-        self.register = Register(init)
 
-    def reset(self):
-        self.register.reset()
+def gen_register_mode(family: TypeFamily, datawidth=None):
+    T = family
+    if datawidth is not None:
+        T = T[datawidth]
 
-    def __call__(self, mode:Mode, const, value, clk_en:Bit):
-        if   mode == Mode.CONST:
-            return const
-        elif mode == Mode.BYPASS:
-            return value
-        elif mode == Mode.DELAY:
-            return self.register(value, mode == Mode.DELAY)
-        elif mode == Mode.VALID:
-            return self.register(value, clk_en)
-        else:
-            raise NotImplementedError()
+    class RegisterMode(Peak):
+        def __init__(self, init=0):
+            self.register: T = gen_register(T)(init)
+
+        def reset(self):
+            self.register.reset()
+
+        def __call__(self, mode: Mode, const, value, clk_en: Bit):
+            if mode == Mode.CONST:
+                self.register(value, False)
+                return const
+            elif mode == Mode.BYPASS:
+                self.register(value, False)
+                return value
+            elif mode == Mode.DELAY:
+                return self.register(value, True)
+            elif mode == Mode.VALID:
+                return self.register(value, clk_en)
+            else:
+                raise NotImplementedError()
+
+    return RegisterMode

--- a/peak/pe/mode.py
+++ b/peak/pe/mode.py
@@ -12,14 +12,10 @@ class Mode(Enum):
     DELAY = 3   # Register written with input value, previous value returned
 
 
-def gen_register_mode(family: TypeFamily, datawidth=None, init=0):
-    T = family
-    if datawidth is not None:
-        T = T[datawidth]
-
+def gen_register_mode(family: TypeFamily, T, init=0):
     class RegisterMode(Peak):
         def __init__(self):
-            self.register: T = gen_register(T, init)()
+            self.register: T = gen_register(family, T, init)()
 
         def reset(self):
             self.register.reset()

--- a/peak/pe/sim.py
+++ b/peak/pe/sim.py
@@ -1,6 +1,6 @@
 from hwtypes import BitVector, SIntVector
 from peak import Peak
-from .mode import RegisterMode
+from .mode import gen_register_mode
 from .cond import cond
 from .lut import lut
 from .isa import *
@@ -11,12 +11,12 @@ def gen_pe(num_inputs):
 
         def __init__(self):
             # Data registers
-            self.data = [(RegisterMode(Data)) for i in range(num_inputs)]
+            self.data = [(gen_register_mode(Data)()) for i in range(num_inputs)]
 
             # Bit Registers
-            self.bit0 = RegisterMode(Bit)
-            self.bit1 = RegisterMode(Bit)
-            self.bit2 = RegisterMode(Bit)
+            self.bit0 = gen_register_mode(Bit)()
+            self.bit1 = gen_register_mode(Bit)()
+            self.bit2 = gen_register_mode(Bit)()
 
         def __call__(self, inst: Inst, \
                         data, \

--- a/peak/pe/sim.py
+++ b/peak/pe/sim.py
@@ -10,13 +10,14 @@ def gen_pe(num_inputs):
     class PE(Peak):
 
         def __init__(self):
+            family = Data.get_family()
             # Data registers
-            self.data = [(gen_register_mode(Data)()) for i in range(num_inputs)]
+            self.data = [(gen_register_mode(family, Data)()) for i in range(num_inputs)]
 
             # Bit Registers
-            self.bit0 = gen_register_mode(Bit)()
-            self.bit1 = gen_register_mode(Bit)()
-            self.bit2 = gen_register_mode(Bit)()
+            self.bit0 = gen_register_mode(family, Bit)()
+            self.bit1 = gen_register_mode(family, Bit)()
+            self.bit2 = gen_register_mode(family, Bit)()
 
         def __call__(self, inst: Inst, \
                         data, \

--- a/peak/pe1/asm.py
+++ b/peak/pe1/asm.py
@@ -25,8 +25,8 @@ def inst(alu, signed=Signed.unsigned, lut=0, cond=Cond.Z,
 
 # helper functions to format configurations
 
-def add():
-    return inst(ALU.Add)
+def add(ra_mode=Mode.BYPASS, rb_mode=Mode.BYPASS):
+    return inst(ALU.Add, ra_mode=ra_mode, rb_mode=rb_mode)
 
 def sub ():
     return inst(ALU.Sub)
@@ -54,14 +54,14 @@ def smult2 ():
 
 
 
-def and_():
-    return inst(ALU.And)
+def and_(ra_mode=Mode.BYPASS, rb_mode=Mode.BYPASS):
+    return inst(ALU.And, ra_mode=ra_mode, rb_mode=rb_mode)
 
-def or_():
-    return inst(ALU.Or)
+def or_(ra_mode=Mode.BYPASS, rb_mode=Mode.BYPASS):
+    return inst(ALU.Or, ra_mode=ra_mode, rb_mode=rb_mode)
 
-def xor():
-    return inst(ALU.XOr)
+def xor(ra_mode=Mode.BYPASS, rb_mode=Mode.BYPASS):
+    return inst(ALU.XOr, ra_mode=ra_mode, rb_mode=rb_mode)
 
 def lsl():
     return inst(ALU.SHL)

--- a/peak/pe1/mode.py
+++ b/peak/pe1/mode.py
@@ -12,14 +12,14 @@ class Mode(Enum):
     DELAY = 3   # Register written with input value, previous value returned
 
 
-def gen_register_mode(family: TypeFamily, datawidth=None):
+def gen_register_mode(family: TypeFamily, datawidth=None, init=0):
     T = family
     if datawidth is not None:
         T = T[datawidth]
 
     class RegisterMode(Peak):
-        def __init__(self, init=0):
-            self.register: T = gen_register(T)(init)
+        def __init__(self):
+            self.register: T = gen_register(T, init)()
 
         def reset(self):
             self.register.reset()

--- a/peak/pe1/mode.py
+++ b/peak/pe1/mode.py
@@ -1,29 +1,41 @@
-from .. import Peak, Register, Enum
+from peak import Peak, gen_register
+from peak.adt import Enum
 from .lut import Bit
+from hwtypes import TypeFamily
+
 
 # Field for specifying register modes
-#
 class Mode(Enum):
     CONST = 0   # Register returns constant in constant field
     VALID = 1   # Register written with clock enable, previous value returned
     BYPASS = 2  # Register is bypassed and input value is returned
     DELAY = 3   # Register written with input value, previous value returned
 
-class RegisterMode(Peak):
-    def __init__(self, init = 0):
-        self.register = Register(init)
 
-    def reset(self):
-        self.register.reset()
+def gen_register_mode(family: TypeFamily, datawidth=None):
+    T = family
+    if datawidth is not None:
+        T = T[datawidth]
 
-    def __call__(self, mode:Mode, const, value, clk_en:Bit):
-        if   mode == Mode.CONST:
-            return const
-        elif mode == Mode.BYPASS:
-            return value
-        elif mode == Mode.DELAY:
-            return self.register(value, True)
-        elif mode == Mode.VALID:
-            return self.register(value, clk_en)
-        else:
-            raise NotImplementedError()
+    class RegisterMode(Peak):
+        def __init__(self, init=0):
+            self.register: T = gen_register(T)(init)
+
+        def reset(self):
+            self.register.reset()
+
+        def __call__(self, mode: Mode, const, value, clk_en: Bit):
+            if mode == Mode.CONST:
+                self.register(value, False)
+                return const
+            elif mode == Mode.BYPASS:
+                self.register(value, False)
+                return value
+            elif mode == Mode.DELAY:
+                return self.register(value, True)
+            elif mode == Mode.VALID:
+                return self.register(value, clk_en)
+            else:
+                raise NotImplementedError()
+
+    return RegisterMode

--- a/peak/pe1/mode.py
+++ b/peak/pe1/mode.py
@@ -12,14 +12,10 @@ class Mode(Enum):
     DELAY = 3   # Register written with input value, previous value returned
 
 
-def gen_register_mode(family: TypeFamily, datawidth=None, init=0):
-    T = family
-    if datawidth is not None:
-        T = T[datawidth]
-
+def gen_register_mode(family: TypeFamily, T, init=0):
     class RegisterMode(Peak):
         def __init__(self):
-            self.register: T = gen_register(T, init)()
+            self.register: T = gen_register(family, T, init)()
 
         def reset(self):
             self.register.reset()

--- a/peak/pe1/sim.py
+++ b/peak/pe1/sim.py
@@ -1,6 +1,6 @@
 from hwtypes import BitVector, SIntVector, overflow
 from .. import Peak, name_outputs
-from .mode import Mode, RegisterMode
+from .mode import Mode, gen_register_mode
 from .lut import Bit, LUT, lut
 from .cond import Cond, cond
 from .isa import *
@@ -98,13 +98,13 @@ class PE(Peak):
         # Declare PE state
 
         # Data registers
-        self.rega = RegisterMode(Data)
-        self.regb = RegisterMode(Data)
+        self.rega = gen_register_mode(Data)()
+        self.regb = gen_register_mode(Data)()
 
         # Bit Registers
-        self.regd = RegisterMode(Bit)
-        self.rege = RegisterMode(Bit)
-        self.regf = RegisterMode(Bit)
+        self.regd = gen_register_mode(Bit)()
+        self.rege = gen_register_mode(Bit)()
+        self.regf = gen_register_mode(Bit)()
 
     @name_outputs(alu_res=Data,res_p=Bit,irq=Bit)
     def __call__(self, inst: Inst, \

--- a/peak/pe1/sim.py
+++ b/peak/pe1/sim.py
@@ -97,14 +97,15 @@ class PE(Peak):
     def __init__(self):
         # Declare PE state
 
+        family = Data.get_family()
         # Data registers
-        self.rega = gen_register_mode(Data)()
-        self.regb = gen_register_mode(Data)()
+        self.rega = gen_register_mode(family, Data)()
+        self.regb = gen_register_mode(family, Data)()
 
         # Bit Registers
-        self.regd = gen_register_mode(Bit)()
-        self.rege = gen_register_mode(Bit)()
-        self.regf = gen_register_mode(Bit)()
+        self.regd = gen_register_mode(family, Bit)()
+        self.rege = gen_register_mode(family, Bit)()
+        self.regf = gen_register_mode(family, Bit)()
 
     @name_outputs(alu_res=Data,res_p=Bit,irq=Bit)
     def __call__(self, inst: Inst, \

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from hwtypes import AbstractBitVector, AbstractBit
 import functools
 from .adt import ISABuilder
+import magma as m
 
 class Peak:
     pass
@@ -33,8 +34,8 @@ def name_outputs(**outputs):
         #Set all the outputs
         call_wrapper._peak_outputs_ = OrderedDict()
         for oname,otype in outputs.items():
-            if not issubclass(otype, (AbstractBitVector, AbstractBit)):
-                raise TypeError(f"{oname} is not a Bitvector class")
+            if not issubclass(otype, (AbstractBitVector, AbstractBit, m.Type)):
+                raise TypeError(f"{oname} is not a Bitvector class or Magma type")
             call_wrapper._peak_outputs_[oname] = otype
 
         #set all the inputs

--- a/peak/pico/isa.py
+++ b/peak/pico/isa.py
@@ -127,5 +127,5 @@ class Control(Sum[Jump, Call, Return]): pass
 
 
 @bitfield(14)
-class Inst(Sum[Logic, Arith, Memory, Control]): pass
+class Inst(Sum[Logic, Arith, Memory, Control, Word]): pass
 

--- a/peak/pico/sim.py
+++ b/peak/pico/sim.py
@@ -1,6 +1,6 @@
 from hwtypes import BitVector, overflow
 from .isa import *
-from .. import Peak, Register, RAM, ROM
+from .. import Peak, gen_register, RAM, ROM
 
 LR = Reg4(15)
 ZERO = Bit(0)
@@ -67,14 +67,14 @@ def cond(code, Z, N, C, V):
 class Pico(Peak):
 
     def __init__(self, mem):
-        self.mem = ROM(Word, 256, mem, Word(0))
+        self.mem = ROM(Inst, 256, mem, Word(0))
 
         self.reg = RAM(Word, 16, [Word(0) for i in range(16)])
-        self.PC = Register(Word, Word(0))
-        self.Z = Register(Bit,ZERO)
-        self.N = Register(Bit,ZERO)
-        self.C = Register(Bit,ZERO)
-        self.V = Register(Bit,ZERO)
+        self.PC = gen_register(Word)(Word(0))
+        self.Z = gen_register(Bit)(ZERO)
+        self.N = gen_register(Bit)(ZERO)
+        self.C = gen_register(Bit)(ZERO)
+        self.V = gen_register(Bit)(ZERO)
 
     def __call__(self):
         pc = self.PC()

--- a/peak/pico/sim.py
+++ b/peak/pico/sim.py
@@ -67,14 +67,15 @@ def cond(code, Z, N, C, V):
 class Pico(Peak):
 
     def __init__(self, mem):
+        family = Bit.get_family()
         self.mem = ROM(Inst, 256, mem, Word(0))
 
         self.reg = RAM(Word, 16, [Word(0) for i in range(16)])
-        self.PC = gen_register(Word, Word(0))()
-        self.Z = gen_register(Bit, ZERO)()
-        self.N = gen_register(Bit, ZERO)()
-        self.C = gen_register(Bit, ZERO)()
-        self.V = gen_register(Bit, ZERO)()
+        self.PC = gen_register(family, Word, Word(0))()
+        self.Z = gen_register(family, Bit, ZERO)()
+        self.N = gen_register(family, Bit, ZERO)()
+        self.C = gen_register(family, Bit, ZERO)()
+        self.V = gen_register(family, Bit, ZERO)()
 
     def __call__(self):
         pc = self.PC()

--- a/peak/pico/sim.py
+++ b/peak/pico/sim.py
@@ -70,11 +70,11 @@ class Pico(Peak):
         self.mem = ROM(Inst, 256, mem, Word(0))
 
         self.reg = RAM(Word, 16, [Word(0) for i in range(16)])
-        self.PC = gen_register(Word)(Word(0))
-        self.Z = gen_register(Bit)(ZERO)
-        self.N = gen_register(Bit)(ZERO)
-        self.C = gen_register(Bit)(ZERO)
-        self.V = gen_register(Bit)(ZERO)
+        self.PC = gen_register(Word, Word(0))()
+        self.Z = gen_register(Bit, ZERO)()
+        self.N = gen_register(Bit, ZERO)()
+        self.C = gen_register(Bit, ZERO)()
+        self.V = gen_register(Bit, ZERO)()
 
     def __call__(self):
         pc = self.PC()

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,17 +1,25 @@
 from .peak import Peak
+from hwtypes import TypeFamily
 
-class Register(Peak):
-    def __init__(self, type, init = 0):
-        self.init = type(init)
-        self.reset()
-    
-    def reset(self): 
-        self.value = self.init
-    
-    def __call__(self, value=None, en=1):
-        retvalue = self.value
-        if value is not None and en:
-            assert value is not None
-            self.value = value
-        return retvalue
 
+def gen_register(family: TypeFamily, datawidth=None):
+    T = family
+    if datawidth is not None:
+        T = T[datawidth]
+
+    class Register(Peak):
+        def __init__(self, init):
+            self.init: T = T(init)
+            self.reset()
+
+        def reset(self):
+            self.value = self.init
+
+        def __call__(self, value=None, en=1):
+            retvalue = self.value
+            if value is not None and en:
+                assert value is not None
+                self.value = value
+            return retvalue
+
+    return Register

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,6 +1,5 @@
 from .peak import Peak
 from hwtypes import BitVector
-import magma as m
 
 
 def gen_register(family, T, init=0):
@@ -14,7 +13,4 @@ def gen_register(family, T, init=0):
                 assert value is not None
                 self.value = value
             return retvalue
-
-    if family.Bit is m.Bit:
-        Register = m.circuit.sequential(Register)
     return Register

--- a/peak/register.py
+++ b/peak/register.py
@@ -3,7 +3,7 @@ from hwtypes import BitVector
 import magma as m
 
 
-def gen_register(T, mode="sim"):
+def gen_register(T, init=0, mode="sim"):
     if mode == "sim":
         family = BitVector.get_family()
     elif mode == "rtl":
@@ -12,7 +12,7 @@ def gen_register(T, mode="sim"):
         raise NotImplementedError(mode)
 
     class Register(Peak):
-        def __init__(self, init):
+        def __init__(self):
             self.value: T = T(init)
 
         def __call__(self, value: T=None, en: family.Bit=1) -> T:

--- a/peak/register.py
+++ b/peak/register.py
@@ -3,12 +3,10 @@ from hwtypes import BitVector
 import magma as m
 
 
-def gen_register(T, init=0):
-    family = T.get_family()
-
+def gen_register(family, T, init=0):
     class Register(Peak):
         def __init__(self):
-            self.value: T = T(init)
+            self.value: T = init
 
         def __call__(self, value: T=None, en: family.Bit=1) -> T:
             retvalue = self.value

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,5 +1,6 @@
 from .peak import Peak
 from hwtypes import BitVector
+import magma as m
 
 
 def gen_register(family, T, init=0):
@@ -13,4 +14,7 @@ def gen_register(family, T, init=0):
                 assert value is not None
                 self.value = value
             return retvalue
+
+    if family.Bit is m.Bit:
+        Register = m.circuit.sequential(Register)
     return Register

--- a/peak/register.py
+++ b/peak/register.py
@@ -3,13 +3,8 @@ from hwtypes import BitVector
 import magma as m
 
 
-def gen_register(T, init=0, mode="sim"):
-    if mode == "sim":
-        family = BitVector.get_family()
-    elif mode == "rtl":
-        family = m.get_family()
-    else:
-        raise NotImplementedError(mode)
+def gen_register(T, init=0):
+    family = T.get_family()
 
     class Register(Peak):
         def __init__(self):
@@ -22,7 +17,6 @@ def gen_register(T, init=0, mode="sim"):
                 self.value = value
             return retvalue
 
-    if mode == "sim":
-        return Register
-    elif mode == "rtl":
-        return m.circuit.sequential(Register)
+    if family.Bit is m.Bit:
+        Register = m.circuit.sequential(Register)
+    return Register

--- a/peak/register.py
+++ b/peak/register.py
@@ -6,7 +6,7 @@ import magma as m
 def gen_register(T, mode="sim"):
     if mode == "sim":
         family = BitVector.get_family()
-    elif mode == "sim":
+    elif mode == "rtl":
         family = m.get_family()
     else:
         raise NotImplementedError(mode)

--- a/peak/register.py
+++ b/peak/register.py
@@ -2,7 +2,7 @@ from .peak import Peak
 
 class Register(Peak):
     def __init__(self, type, init = 0):
-        self.init = init
+        self.init = type(init)
         self.reset()
     
     def reset(self): 

--- a/peak/register.py
+++ b/peak/register.py
@@ -4,7 +4,12 @@ import magma as m
 
 
 def gen_register(T, mode="sim"):
-    family = BitVector.get_family()
+    if mode == "sim":
+        family = BitVector.get_family()
+    elif mode == "sim":
+        family = m.get_family()
+    else:
+        raise NotImplementedError(mode)
 
     class Register(Peak):
         def __init__(self, init):
@@ -21,4 +26,3 @@ def gen_register(T, mode="sim"):
         return Register
     elif mode == "rtl":
         return m.circuit.sequential(Register)
-    raise NotImplementedError(mode)

--- a/peak/register.py
+++ b/peak/register.py
@@ -1,25 +1,24 @@
 from .peak import Peak
-from hwtypes import TypeFamily
+from hwtypes import BitVector
+import magma as m
 
 
-def gen_register(family: TypeFamily, datawidth=None):
-    T = family
-    if datawidth is not None:
-        T = T[datawidth]
+def gen_register(T, mode="sim"):
+    family = BitVector.get_family()
 
     class Register(Peak):
         def __init__(self, init):
-            self.init: T = T(init)
-            self.reset()
+            self.value: T = T(init)
 
-        def reset(self):
-            self.value = self.init
-
-        def __call__(self, value=None, en=1):
+        def __call__(self, value: T=None, en: family.Bit=1) -> T:
             retvalue = self.value
             if value is not None and en:
                 assert value is not None
                 self.value = value
             return retvalue
 
-    return Register
+    if mode == "sim":
+        return Register
+    elif mode == "rtl":
+        return m.circuit.sequential(Register)
+    raise NotImplementedError(mode)

--- a/tests/test_pico.py
+++ b/tests/test_pico.py
@@ -20,7 +20,7 @@ def test_ldhi():
     assert pico.peak_reg(0) == 10 << 8
 
 def test_ld():
-    mem = [asm.ldlo(0,1),asm.ldhi(1,2),asm.or_(0,1)]
+    mem = [asm.ldlo(0,1), asm.ldhi(1,2), asm.or_(0,1)]
     pico = Pico(mem)
     pico()
     pico()


### PR DESCRIPTION
* Makes register use the closure pattern over the type family
  * This temporarily updates related code to support this pattern, but all the peak internal code is not fully closed over the family, instead the top level functions were set to use the hwtypes family so the existing simulation tests work. this is fine for RTL since we're working off lassen, so the code internal to peak doesn't need to be generic (yet)
* Adds a method `bit_length()` on enum to get the bit length of the type