### PR TITLE
add cache to peak definition

### DIFF
--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -7,6 +7,7 @@ import operator
 import ast
 import magma as m
 
+
 def _issubclass(sub , parent : type) -> bool:
     try:
         return issubclass(sub, parent)

--- a/peak/rtl_utils.py
+++ b/peak/rtl_utils.py
@@ -1,6 +1,7 @@
 import magma as m
 
 
+@m.cache_definition
 def wrap_with_disassembler(PE, disassembler, width, layout, inst_type):
     WrappedIO = []
     for key, value in PE.interface.ports.items():


### PR DESCRIPTION
Caveat: The caller has to convert the `generate_assembler` into hashable objects. Ideally it should be handled inside the `generate_assembler` call.