### PR TITLE
Fix issue in peak rtl assembler logic

### DIFF
--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -207,7 +207,7 @@ def assemble_values_in_func(assemblers, peak_fn, _locals, _globals):
     func_def = ISABuilderAssembler(assemblers, _locals, _globals).visit(func_def)
     func_def = ast.fix_missing_locations(func_def)
     temp_dir = tempfile.TemporaryDirectory()
-    file_name = os.path.join(temp_dir, peak_fn.__name__ + ".py")
+    file_name = os.path.join(temp_dir.name, peak_fn.__name__ + ".py")
     with open(file_name, "w") as fp:
         fp.write(astor.to_source(func_def))
     try:

--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -1,4 +1,3 @@
-import sys
 import traceback
 import os
 import astor

--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -207,8 +207,8 @@ def assemble_values_in_func(assemblers, peak_fn, _locals, _globals):
     func_def = m.ast_utils.get_ast(peak_fn).body[0]
     func_def = ISABuilderAssembler(assemblers, _locals, _globals).visit(func_def)
     func_def = ast.fix_missing_locations(func_def)
-    temp_dir = tempfile.TemporaryDirectory()
-    file_name = os.path.join(temp_dir.name, peak_fn.__name__ + ".py")
+    temp_dir = tempfile.mkdtemp()
+    file_name = os.path.join(temp_dir, peak_fn.__name__ + ".py")
     with open(file_name, "w") as fp:
         fp.write(astor.to_source(func_def))
     try:

--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -11,6 +11,7 @@ import operator
 import ast
 import magma as m
 import tempfile
+import logging
 
 
 def _issubclass(sub , parent : type) -> bool:
@@ -215,6 +216,6 @@ def assemble_values_in_func(assemblers, peak_fn, _locals, _globals):
              _globals, _locals)
     except:
         tb = traceback.format_exc()
-        print(tb)
+        logging.error(tb)
         raise Exception(f"Error occured when compiling and executing assemble_values_in_func on function {peak_fn.__name__}, see above") from None
     return _locals[peak_fn.__name__]

--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -205,9 +205,6 @@ class ISABuilderAssembler(ast.NodeTransformer):
 def assemble_values_in_func(assemblers, peak_fn, _locals, _globals):
     func_def = m.ast_utils.get_ast(peak_fn).body[0]
     func_def = ISABuilderAssembler(assemblers, _locals, _globals).visit(func_def)
-    # Uncomment to see result of AST rewrite
-    # import astor
-    # print(astor.to_source(func_def))
     func_def = ast.fix_missing_locations(func_def)
     os.makedirs(".peak", exist_ok=True)
     file_name = os.path.join(".peak", peak_fn.__name__ + ".py")

--- a/peak/auto_assembler.py
+++ b/peak/auto_assembler.py
@@ -11,6 +11,7 @@ from hwtypes.adt_meta import EnumMeta
 import operator
 import ast
 import magma as m
+import tempfile
 
 
 def _issubclass(sub , parent : type) -> bool:
@@ -206,8 +207,8 @@ def assemble_values_in_func(assemblers, peak_fn, _locals, _globals):
     func_def = m.ast_utils.get_ast(peak_fn).body[0]
     func_def = ISABuilderAssembler(assemblers, _locals, _globals).visit(func_def)
     func_def = ast.fix_missing_locations(func_def)
-    os.makedirs(".peak", exist_ok=True)
-    file_name = os.path.join(".peak", peak_fn.__name__ + ".py")
+    temp_dir = tempfile.TemporaryDirectory()
+    file_name = os.path.join(temp_dir, peak_fn.__name__ + ".py")
     with open(file_name, "w") as fp:
         fp.write(astor.to_source(func_def))
     try:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     ],
     install_requires=[
         "hwtypes >= 1.0.1",
+        "astor",
         "pysmt",
         "magma-lang",
         "coreir",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -56,6 +56,10 @@ def test_ast_rewrite():
     runs the AST rewrite logic to replace uses of the `Cond` enum type with the
     assembled value (using `ISABuilderAssembler` which is the core logic of
     `assemble_values_in_func`).
+
+    The function `cond_expected` is the expected code after running the AST
+    rewriter (we dump the rewritten AST and compare it to the AST of
+    `cond_expected` as the check)
     """
     def gen_cond(enum):
         class Cond(enum):

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -112,50 +112,55 @@ def test_ast_rewrite():
         elif code == Cond.LUT:
             return lut
 
-    def cond_expected(code: Cond, alu: Bit, lut: Bit, Z: Bit, N: Bit, C: Bit,
-                      V: Bit) -> Bit:
-        if code == assemble(Cond.Z):
+    def cond_expected(code: Cond, alu: Bit, lut: Bit, Z: Bit, N: Bit, C: Bit, V: Bit) ->Bit:
+        if code == 0:
             return Z
-        elif code == assemble(Cond.Z_n):
+        elif code == 1:
             return not Z
-        elif code == assemble(Cond.C) or code == assemble(Cond.UGE):
+        elif code == 2 or code == 2:
             return C
-        elif code == assemble(Cond.C_n) or code == assemble(Cond.ULT):
+        elif code == 3 or code == 3:
             return not C
-        elif code == assemble(Cond.N):
+        elif code == 4:
             return N
-        elif code == assemble(Cond.N_n):
+        elif code == 5:
             return not N
-        elif code == assemble(Cond.V):
+        elif code == 6:
             return V
-        elif code == assemble(Cond.V_n):
+        elif code == 7:
             return not V
-        elif code == assemble(Cond.UGT):
+        elif code == 8:
             return C and not Z
-        elif code == assemble(Cond.ULE):
+        elif code == 9:
             return not C or Z
-        elif code == assemble(Cond.SGE):
+        elif code == 10:
             return N == V
-        elif code == assemble(Cond.SLT):
+        elif code == 11:
             return N != V
-        elif code == assemble(Cond.SGT):
-            return not Z and (N == V)
-        elif code == assemble(Cond.SLE):
-            return Z or (N != V)
-        elif code == assemble(Cond.ALU):
+        elif code == 12:
+            return not Z and N == V
+        elif code == 13:
+            return Z or N != V
+        elif code == 15:
             return alu
-        elif code == assemble(Cond.LUT):
+        elif code == 14:
             return lut
 
+    peak_cond = gen_cond(Enum)
     assembler, disassembler, width, layout = \
-        generate_assembler(gen_cond(Enum))
+        generate_assembler(peak_cond)
     func_def = m.ast_utils.get_ast(cond).body[0]
-    func_def = ISABuilderAssembler(locals(), globals()).visit(func_def)
+    assemblers = {
+        Cond: (peak_cond, assembler)
+    }
+    func_def = ISABuilderAssembler(assemblers, locals(), globals()).visit(func_def)
+    # import astor
+    # print(astor.to_source(func_def))
     assert [ast.dump(s) for s in func_def.body] == \
         [ast.dump(s) for s in m.ast_utils.get_ast(cond_expected).body[0].body]
 
     # Call the front end to make sure it works
-    cond = assemble_values_in_func(assembler, cond, locals(), globals())
+    cond = assemble_values_in_func(assemblers, cond, locals(), globals())
 
 def test_enum_determinism():
     def assemble():

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -51,6 +51,12 @@ def test_assembler_disassembler(isa):
 
 
 def test_ast_rewrite():
+    """
+    This test takes a function `cond` that is generic (e.g. uses `Cond.Z`) and
+    runs the AST rewrite logic to replace uses of the `Cond` enum type with the
+    assembled value (using `ISABuilderAssembler` which is the core logic of
+    `assemble_values_in_func`).
+    """
     def gen_cond(enum):
         class Cond(enum):
             Z = 0    # EQ
@@ -154,8 +160,6 @@ def test_ast_rewrite():
         Cond: (peak_cond, assembler)
     }
     func_def = ISABuilderAssembler(assemblers, locals(), globals()).visit(func_def)
-    # import astor
-    # print(astor.to_source(func_def))
     assert [ast.dump(s) for s in func_def.body] == \
         [ast.dump(s) for s in m.ast_utils.get_ast(cond_expected).body[0].body]
 


### PR DESCRIPTION
Two issues:
1. `locals` and `globals` were passed in the wrong order to exec, which means the redefinition of the function with the assembler rewrites wasn't actually happening properly. When I fixed this, I ran into an issue where magma was trying to fetch the source code of the redefined function (with `assemble` called on the various peak values), so I had to change the logic to generate a file with the code so magma could retrieve it.
2. `assemble` logic wasn't actually working as intended, but somehow it was working in our flow? Anyways, I changed it so that the rewriter is actually invoking the assembler in the pass and inserts the raw assembled `int` value into the AST. This changes the interface where the user must pass assemblers for each type being rewritten (i.e. the result of calling `generate_assembler(<type>)`). This is the form of a dictionary mapping `{<magma_type>: (<peak_type>, <assembler>)}`, so the user needs to create this dictionary for the rewrite to occur (we need the original peak_type to get the field to be passed to the assembler).

There's probably a way to improve this interface, but I think we need to discuss it, however this change will unblock https://github.com/StanfordAHA/lassen/pull/99