### PR TITLE
Remove reg default value

### DIFF
--- a/peak/memory.py
+++ b/peak/memory.py
@@ -10,10 +10,10 @@ class ROM(Peak):
             self.mem.append( gen_register(BitVector.get_family(), type, init=data)() )
         
     def __call__(self, addr):
-        return self.mem[int(addr)]()
+        return self.mem[int(addr)](0, 0)
 
 class RAM(ROM):
-    def __call__(self, addr, data=None, wen=1):
+    def __call__(self, addr, data, wen):
         return self.mem[int(addr)](data, wen)
 
 Memory = RAM

--- a/peak/register.py
+++ b/peak/register.py
@@ -13,6 +13,10 @@ def gen_register(family, T, init=0):
             retvalue = self.value
             if en:
                 self.value = value
+            else:
+                # Bug in magma sequential syntax without default values, we
+                # explicitly set it for now
+                self.value = self.value
             return retvalue
 
     if family.Bit is m.Bit:

--- a/peak/register.py
+++ b/peak/register.py
@@ -8,10 +8,10 @@ def gen_register(family, T, init=0):
         def __init__(self):
             self.value: T = init
 
-        def __call__(self, value: T=None, en: family.Bit=1) -> T:
+        def __call__(self, value: T, en: family.Bit) -> T:
+            assert value is not None
             retvalue = self.value
-            if value is not None and en:
-                assert value is not None
+            if en:
                 self.value = value
             return retvalue
 


### PR DESCRIPTION
This removes the default parameters `value: T=None, en: family.Bit=1` from the peak register which was causing issue with the magma sequential compiler (it doesn't support these default values, also checking for `None` input values (`if value is not None and en:`) doesn't currently have a mapping to synthesizable code.