### PR TITLE
Fix or-reduce initial condition for enum is_valid checks

### DIFF
--- a/peak/assembler/assembler_util.py
+++ b/peak/assembler/assembler_util.py
@@ -118,6 +118,6 @@ def _gen_is_valid(
                 return ft.reduce(
                         operator.or_,
                         (f(opcode) for f in range_validators),
-                        opcode.get_family().Bit(1))
+                        opcode.get_family().Bit(0))
 
     return _validator_cache.setdefault(opcodes, is_valid)

--- a/peak/assembler2/assembler_util.py
+++ b/peak/assembler2/assembler_util.py
@@ -118,6 +118,6 @@ def _gen_is_valid(
                 return ft.reduce(
                         operator.or_,
                         (f(opcode) for f in range_validators),
-                        opcode.get_family().Bit(1))
+                        opcode.get_family().Bit(0))
 
     return _validator_cache.setdefault(opcodes, is_valid)


### PR DESCRIPTION
I believe the initial condition in these reduce ORings should be 0 and not 1. 1 results in the condition automatically being true. 